### PR TITLE
Avoid passing non-Node value to make_foreignscan() as 'fdw_private'

### DIFF
--- a/expected/treasuredata_fdw.out.erb
+++ b/expected/treasuredata_fdw.out.erb
@@ -91,6 +91,21 @@ SELECT COUNT(1) FROM (SELECT * FROM td_www_access LIMIT 1) x WHERE size > 0;
      1
 (1 row)
 
+BEGIN;
+DECLARE cur CURSOR FOR SELECT time FROM td_www_access WHERE time < 1412320911 ORDER BY time;
+FETCH cur;
+    time    
+------------
+ 1412320845
+(1 row)
+
+FETCH cur;
+    time    
+------------
+ 1412320861
+(1 row)
+
+COMMIT;
 CREATE FOREIGN TABLE td_summary_in_www_access (
     code integer,
     method varchar,

--- a/sql/treasuredata_fdw.sql.erb
+++ b/sql/treasuredata_fdw.sql.erb
@@ -27,6 +27,11 @@ SELECT COUNT(1) FROM td_www_access WHERE SUBSTRING(method, 1, 2) || SUBSTR(metho
 SELECT COUNT(1) FROM td_www_access WHERE agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:9.0.1) Gecko/20100101 Firefox/9.0.1' OR agent LIKE 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:10.0.1)%' OR agent IN ('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)', 'Mozilla/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3');
 -- For https://github.com/komamitsu/treasuredata_fdw/issues/23
 SELECT COUNT(1) FROM (SELECT * FROM td_www_access LIMIT 1) x WHERE size > 0;
+BEGIN;
+DECLARE cur CURSOR FOR SELECT time FROM td_www_access WHERE time < 1412320911 ORDER BY time;
+FETCH cur;
+FETCH cur;
+COMMIT;
 CREATE FOREIGN TABLE td_summary_in_www_access (
     code integer,
     method varchar,


### PR DESCRIPTION
If the `fdw_private` contains non-Node value, calling copyObject() fails. This issue can occur with CURSOR statements.