### PR TITLE
Import foreign schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ before_install: curl -sSf https://static.rust-lang.org/rustup.sh | sudo sh
 install: make && sudo make install
 
 script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./setup_regress presto && travis_wait make installcheck; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./setup_regress hive && travis_wait make installcheck; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./setup_regress presto && travis_wait make installcheck; if [ $? -ne 0 ]; then cat regression.diffs && false; fi; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./setup_regress hive && travis_wait make installcheck; if [ $? -ne 0 ]; then cat regression.diffs && false; fi; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ before_install: curl -sSf https://static.rust-lang.org/rustup.sh | sudo sh
 install: make && sudo make install
 
 script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./setup_regress presto && travis_wait make installcheck; if [ $? -ne 0 ]; then cat regression.diffs && false; fi; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./setup_regress hive && travis_wait make installcheck; if [ $? -ne 0 ]; then cat regression.diffs && false; fi; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./setup_regress presto && travis_wait make installcheck; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./setup_regress hive && travis_wait make installcheck; fi'

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ INTO local_schema OPTIONS (
 \det+ local_schema.
                                                                                      List of foreign tables
     Schema    |   Table    |       Server        |                                                          FDW Options                                                           | Description
---------------+------------+---------------------+--------------------------------------------------------------------------------------------------------------------------------+-------------
- local_schema | nasdaq     | treasuredata_server | (apikey '1/52d34b5d7d8087fd20b38a9c8d4de5e5ea0a8ece', database 'sample_datasets', query_engine 'presto', "table" 'nasdaq')     |
- local_schema | www_access | treasuredata_server | (apikey '1/52d34b5d7d8087fd20b38a9c8d4de5e5ea0a8ece', database 'sample_datasets', query_engine 'presto', "table" 'www_access') |
+--------------|------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------|-------------
+ local_schema | nasdaq     | treasuredata_server | (apikey 'your_api_key', database 'sample_datasets', query_engine 'presto', "table" 'nasdaq')     |
+ local_schema | www_access | treasuredata_server | (apikey 'your_api_key', database 'sample_datasets', query_engine 'presto', "table" 'www_access') |
 (2 rows)
 ```
 Note that "time" column will NOT be imported by IMPORT FOREIGN SCHEMA.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ SERVER treasuredata_fdw OPTIONS (
         :
 ```
 
+You can also use IMPORT FOREIGN SCHEMA.
+It will import the tables on the specified Treasure Data database into the Postgres schema.
+```
+CREATE SCHEMA local_schema;
+IMPORT FOREIGN SCHEMA sample_datasets
+FROM SERVER treasuredata_server
+INTO local_schema OPTIONS (
+    apikey 'your_api_key',
+    query_engine 'presto'
+);
+\det+ local_schema.
+                                                                                     List of foreign tables
+    Schema    |   Table    |       Server        |                                                          FDW Options                                                           | Description
+--------------+------------+---------------------+--------------------------------------------------------------------------------------------------------------------------------+-------------
+ local_schema | nasdaq     | treasuredata_server | (apikey '1/52d34b5d7d8087fd20b38a9c8d4de5e5ea0a8ece', database 'sample_datasets', query_engine 'presto', "table" 'nasdaq')     |
+ local_schema | www_access | treasuredata_server | (apikey '1/52d34b5d7d8087fd20b38a9c8d4de5e5ea0a8ece', database 'sample_datasets', query_engine 'presto', "table" 'www_access') |
+(2 rows)
+```
+Note that "time" column will NOT be imported by IMPORT FOREIGN SCHEMA.
+
 ## Table Options
 
 - apikey : API Key for Treasure Data. See [Get API Keys](https://docs.treasuredata.com/articles/get-apikey).
@@ -146,6 +166,9 @@ SERVER treasuredata_fdw OPTIONS (
 - import_file_size : Approximate maximum size of chunk files uploaded to Treasure Data. The default value is `134217728` (128MB).
 - atomic_import : Flag (`true` or `false`) of whether uploaded chunk files get visible atomically. The default value is `false`
 
+On IMPORT FOREIGN SCHEMA, you must specify apikey and query_engine. You can also specify endpoint which is optional.
+Those values will be set into the imported tables' option.
+You can use ALTER FOREIGN TABLE to modify table options if you want to modify after import.
 
 ## INSERT INTO statement
 

--- a/bridge.c
+++ b/bridge.c
@@ -136,7 +136,7 @@ extern void import_commit(
     void (*error_log)(size_t, const char *)
 );
 
-extern table_schemas_t *get_tables(
+extern table_schemas_t *get_table_schemas(
     const char *apikey,
     const char *endpoint,
     const char *database,
@@ -316,12 +316,12 @@ static void *pgstrdup(size_t len, const char *s)
 	return buf;
 }
 
-table_schemas_t *getTables(
+table_schemas_t *getTableSchemas(
     const char *apikey,
     const char *endpoint,
     const char *database)
 {
-	return get_tables(
+	return get_table_schemas(
 	           apikey,
 	           endpoint,
 	           database,

--- a/bridge.c
+++ b/bridge.c
@@ -136,18 +136,15 @@ extern void import_commit(
     void (*error_log)(size_t, const char *)
 );
 
-extern int get_tables(
+extern table_schemas_t *get_tables(
     const char *apikey,
     const char *endpoint,
     const char *database,
-    table_schema_t **tables,
     void *(*pgstrdup)(size_t, const char*),
     void *(*pgalloc)(size_t),
     void (*debug_log)(size_t, const char *),
     void (*error_log)(size_t, const char *)
 );
-
-extern void release_table_resource(table_schema_t *tables);
 
 void *issueQuery(
     const char *apikey,
@@ -319,17 +316,15 @@ static void *pgstrdup(size_t len, const char *s)
 	return buf;
 }
 
-int getTables(
+table_schemas_t *getTables(
     const char *apikey,
     const char *endpoint,
-    const char *database,
-    table_schema_t **tables)
+    const char *database)
 {
 	return get_tables(
 	           apikey,
 	           endpoint,
 	           database,
-	           tables,
 	           pgstrdup,
 	           pgalloc,
 	           debug_log,

--- a/bridge.c
+++ b/bridge.c
@@ -20,7 +20,6 @@
 
 #include <postgres.h>
 #define LOG_LEVEL_DEBUG DEBUG1
-#define LOG_LEVEL_WARNING WARNING
 #define LOG_LEVEL_ERROR ERROR
 #define ALLOC(sz) (palloc(sz))
 #define FREE(p) (pfree(p))
@@ -46,7 +45,6 @@ static int add_nil(fetch_result_context *context);
 static int add_bytes(fetch_result_context *context, size_t len, const char *s);
 static List *plappend(List *list, size_t len, const char *s);
 static void debug_log(size_t len, const char *msg);
-static void warning_log(size_t len, const char *msg);
 static void error_log(size_t len, const char *msg);
 
 extern void *issue_query(
@@ -147,7 +145,6 @@ extern List *import_schema(
 	List *commands,
     List *(*plappend)(List *, size_t, const char *),
     void (*debug_log)(size_t, const char *),
-	void (*warning_log)(size_t, const char *),
     void (*error_log)(size_t, const char *)
 );
 #endif
@@ -327,7 +324,6 @@ List *importSchema(
 		commands,
 		plappend,
 		debug_log,
-		warning_log,
 		error_log);
 }
 
@@ -377,12 +373,6 @@ static void
 debug_log(size_t len, const char *msg)
 {
 	call_elog(LOG_LEVEL_DEBUG, len, msg);
-}
-
-static void
-warning_log(size_t len, const char *msg)
-{
-	call_elog(LOG_LEVEL_WARNING, len, msg);
 }
 
 static void

--- a/bridge.h
+++ b/bridge.h
@@ -13,11 +13,6 @@
 #ifndef TREASUREDATA_FDW_BRIDGE_H
 #define TREASUREDATA_FDW_BRIDGE_H
 
-#ifndef WITHOUT_PG
-#include "c.h"
-#include "nodes/pg_list.h"
-#endif
-
 typedef struct
 {
 	char *name;
@@ -25,6 +20,12 @@ typedef struct
 	char **colnames;
 	char **coltypes;
 } table_schema_t;
+
+typedef struct
+{
+	size_t numtables;
+	table_schema_t **tables;
+} table_schemas_t;
 
 extern void* issueQuery(
     const char *apikey,
@@ -83,11 +84,10 @@ extern size_t importAppend(void *import_state, const char **values);
 
 extern void importCommit(void *import_state);
 
-extern int getTables(
+extern table_schemas_t *getTables(
     const char *apikey,
     const char *endpoint,
-    const char *database,
-    table_schema_t **tables);
+    const char *database);
 
 #endif   /* TREASUREDATA_FDW_BRIDGE_H */
 

--- a/bridge.h
+++ b/bridge.h
@@ -18,6 +18,14 @@
 #include "nodes/pg_list.h"
 #endif
 
+typedef struct
+{
+	char *name;
+	size_t numcols;
+	char **colnames;
+	char **coltypes;
+} table_schema_t;
+
 extern void* issueQuery(
     const char *apikey,
     const char *endpoint,
@@ -75,15 +83,11 @@ extern size_t importAppend(void *import_state, const char **values);
 
 extern void importCommit(void *import_state);
 
-#ifndef WITHOUT_PG
-List *importSchema(
-	const char *apikey,
+extern int getTables(
+    const char *apikey,
     const char *endpoint,
-	const char *query_engine,
-	const char *database,
-	const char *server,
-	List *commands);
-#endif
+    const char *database,
+    table_schema_t **tables);
 
 #endif   /* TREASUREDATA_FDW_BRIDGE_H */
 

--- a/bridge.h
+++ b/bridge.h
@@ -13,6 +13,11 @@
 #ifndef TREASUREDATA_FDW_BRIDGE_H
 #define TREASUREDATA_FDW_BRIDGE_H
 
+#ifndef WITHOUT_PG
+#include "c.h"
+#include "nodes/pg_list.h"
+#endif
+
 extern void* issueQuery(
     const char *apikey,
     const char *endpoint,
@@ -69,6 +74,16 @@ extern void *importBegin(
 extern size_t importAppend(void *import_state, const char **values);
 
 extern void importCommit(void *import_state);
+
+#ifndef WITHOUT_PG
+List *importSchema(
+	const char *apikey,
+    const char *endpoint,
+	const char *query_engine,
+	const char *database,
+	const char *server,
+	List *commands);
+#endif
 
 #endif   /* TREASUREDATA_FDW_BRIDGE_H */
 

--- a/bridge.h
+++ b/bridge.h
@@ -84,7 +84,7 @@ extern size_t importAppend(void *import_state, const char **values);
 
 extern void importCommit(void *import_state);
 
-extern table_schemas_t *getTables(
+extern table_schemas_t *getTableSchemas(
     const char *apikey,
     const char *endpoint,
     const char *database);

--- a/bridge_td_client_rust/Cargo.lock
+++ b/bridge_td_client_rust/Cargo.lock
@@ -1,15 +1,3 @@
-[root]
-name = "bridge_td_client"
-version = "0.1.0"
-dependencies = [
- "hyper 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "td-client 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
@@ -22,6 +10,20 @@ dependencies = [
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bridge_td_client"
+version = "0.1.0"
+dependencies = [
+ "hyper 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "td-client 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "byteorder"
@@ -65,6 +67,11 @@ dependencies = [
 [[package]]
 name = "custom_derive"
 version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dtoa"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -134,6 +141,11 @@ dependencies = [
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -400,6 +412,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "solicit"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
@@ -574,6 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum hyper 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "1b9bf64f730d6ee4b0528a5f0a316363da9d8104318731509d4ccc86248f82b3"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
+"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
@@ -608,6 +638,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29af0205707de955a396a1d3c657677c65f791ebabb63c0596c0b2fec0bf6325"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
+"checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
+"checksum serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9db7266c7d63a4c4b7fe8719656ccdd51acf1bed6124b174f933b009fb10bcb"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum td-client 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "746159802b44398077996416d0fca1dd236d647ccf2104a7b7249bf50649d34e"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"

--- a/bridge_td_client_rust/Cargo.toml
+++ b/bridge_td_client_rust/Cargo.toml
@@ -12,4 +12,6 @@ libc = '0.1'
 retry = '0.4'
 time = '0.1'
 uuid = { version = "0.4", features = ["v4"] }
+serde = "1.0"
+serde_json = "1.0"
 td-client = '0.7'

--- a/bridge_td_client_rust/src/lib.rs
+++ b/bridge_td_client_rust/src/lib.rs
@@ -759,7 +759,7 @@ pub extern fn import_commit(
         Ok(readable_chunk) => {
             match Retry::new(
                 &mut || client.import_msgpack_gz_file_to_table(
-                             database, table,
+                            database, table,
                             &readable_chunk.file_path.as_str(),
                             Some(uuid.simple().to_string().as_str())),
                 &mut |result| test_if_needs_to_retry(result)

--- a/bridge_td_client_rust/src/lib.rs
+++ b/bridge_td_client_rust/src/lib.rs
@@ -792,7 +792,6 @@ pub extern fn import_schema(
     mut commands: *mut c_void,
     plappend: extern fn(*mut c_void, usize, &[u8]) -> *mut c_void,
     debug_log: extern fn(usize, &[u8]),
-    warning_log: extern fn(usize, &[u8]),
     error_log: extern fn(usize, &[u8])) -> *mut c_void {
 
     let apikey = convert_str_from_raw_str(raw_apikey);
@@ -802,7 +801,7 @@ pub extern fn import_schema(
     let server = convert_str_from_raw_str(raw_server);
 
     match import_schema_internal(apikey, endpoint, query_engine, database,
-                                 server, debug_log, warning_log, error_log) {
+                                 server, debug_log, error_log) {
         Ok(queries) => {
             for query in &queries {
                 let query_byte = query.as_bytes();
@@ -821,7 +820,6 @@ fn import_schema_internal(
     database: &str,
     server: &str,
     debug_log: extern fn(usize, &[u8]),
-    warning_log: extern fn(usize, &[u8]),
     error_log: extern fn(usize, &[u8])) -> Result<Vec<String>, String> {
     // TODO better error handling
     log!(debug_log, "import_schema: entering");

--- a/expected/treasuredata_fdw.out.erb
+++ b/expected/treasuredata_fdw.out.erb
@@ -243,6 +243,24 @@ SELECT code, size, method FROM local_schema.www_access ORDER BY size, code LIMIT
   200 |   40 | GET
 (5 rows)
 
+SET client_min_messages = 'warning';
+IMPORT FOREIGN SCHEMA treasuredata_fdw LIMIT TO (array_test)
+FROM SERVER treasuredata_server
+INTO local_schema OPTIONS (
+    apikey '<%= @apikey %>',
+    query_engine '<%= @query_engine %>'
+);
+WARNING:  It is not supported to import tables which include array type column. Skip table 'array_test'
+RESET client_min_messages;
+\det local_schema.array_test
+ List of foreign tables
+ Schema | Table | Server 
+--------+-------+--------
+(0 rows)
+
+-- ===================================================================
+-- clean up
+-- ===================================================================
 DROP FOREIGN TABLE td_www_access_dst;
 DROP FOREIGN TABLE td_summary_in_www_access;
 DROP FOREIGN TABLE td_www_access;

--- a/expected/treasuredata_fdw.out.erb
+++ b/expected/treasuredata_fdw.out.erb
@@ -180,6 +180,9 @@ SELECT COUNT(1) FROM td_array_test WHERE 'two' = any(str_array);
      1
 (1 row)
 
+-- ===================================================================
+-- import foreign schema
+-- ===================================================================
 CREATE SCHEMA local_schema;
 IMPORT FOREIGN SCHEMA sample_datasets
 FROM SERVER treasuredata_server
@@ -223,9 +226,7 @@ DROP FOREIGN TABLE td_www_access_dst;
 DROP FOREIGN TABLE td_summary_in_www_access;
 DROP FOREIGN TABLE td_www_access;
 DROP FOREIGN TABLE td_array_test;
+SET client_min_messages = 'error'; -- pg9.6 print NOTICE log in the next command but pg9.5 does not
 DROP SCHEMA local_schema CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to foreign table local_schema.nasdaq
-drop cascades to foreign table local_schema.www_access
 DROP SERVER treasuredata_server;
 DROP EXTENSION treasuredata_fdw CASCADE;

--- a/expected/treasuredata_fdw.out.erb
+++ b/expected/treasuredata_fdw.out.erb
@@ -180,9 +180,52 @@ SELECT COUNT(1) FROM td_array_test WHERE 'two' = any(str_array);
      1
 (1 row)
 
+CREATE SCHEMA local_schema;
+IMPORT FOREIGN SCHEMA sample_datasets
+FROM SERVER treasuredata_server
+INTO local_schema OPTIONS (
+    apikey '<%= @apikey %>',
+    query_engine '<%= @query_engine %>'
+);
+SELECT table_schema, table_name, column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = 'local_schema'
+ORDER BY table_name, ordinal_position;
+ table_schema | table_name | column_name |    data_type     
+--------------+------------+-------------+------------------
+ local_schema | nasdaq     | symbol      | text
+ local_schema | nasdaq     | open        | double precision
+ local_schema | nasdaq     | volume      | bigint
+ local_schema | nasdaq     | high        | double precision
+ local_schema | nasdaq     | low         | double precision
+ local_schema | nasdaq     | close       | double precision
+ local_schema | www_access | user        | integer
+ local_schema | www_access | host        | text
+ local_schema | www_access | path        | text
+ local_schema | www_access | referer     | text
+ local_schema | www_access | code        | bigint
+ local_schema | www_access | agent       | text
+ local_schema | www_access | size        | bigint
+ local_schema | www_access | method      | text
+(14 rows)
+
+SELECT code, size, method FROM local_schema.www_access ORDER BY size, code LIMIT 5;
+ code | size | method 
+------+------+--------
+  200 |   40 | GET
+  200 |   40 | GET
+  200 |   40 | GET
+  200 |   40 | GET
+  200 |   40 | GET
+(5 rows)
+
 DROP FOREIGN TABLE td_www_access_dst;
 DROP FOREIGN TABLE td_summary_in_www_access;
 DROP FOREIGN TABLE td_www_access;
 DROP FOREIGN TABLE td_array_test;
+DROP SCHEMA local_schema CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table local_schema.nasdaq
+drop cascades to foreign table local_schema.www_access
 DROP SERVER treasuredata_server;
 DROP EXTENSION treasuredata_fdw CASCADE;

--- a/expected/treasuredata_fdw.out.erb
+++ b/expected/treasuredata_fdw.out.erb
@@ -243,20 +243,41 @@ SELECT code, size, method FROM local_schema.www_access ORDER BY size, code LIMIT
   200 |   40 | GET
 (5 rows)
 
-SET client_min_messages = 'warning';
 IMPORT FOREIGN SCHEMA treasuredata_fdw LIMIT TO (array_test)
 FROM SERVER treasuredata_server
 INTO local_schema OPTIONS (
     apikey '<%= @apikey %>',
     query_engine '<%= @query_engine %>'
 );
-WARNING:  It is not supported to import tables which include array type column. Skip table 'array_test'
-RESET client_min_messages;
-\det local_schema.array_test
- List of foreign tables
- Schema | Table | Server 
---------+-------+--------
-(0 rows)
+SELECT table_schema, table_name, column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = 'local_schema' AND table_name = 'array_test'
+ORDER BY table_name, ordinal_position;
+ table_schema | table_name |    column_name     | data_type 
+--------------+------------+--------------------+-----------
+ local_schema | array_test | str_array          | ARRAY
+ local_schema | array_test | int_array          | ARRAY
+ local_schema | array_test | long_array         | ARRAY
+ local_schema | array_test | float_array        | ARRAY
+ local_schema | array_test | double_array       | ARRAY
+ local_schema | array_test | str_array_array    | ARRAY
+ local_schema | array_test | int_array_array    | ARRAY
+ local_schema | array_test | long_array_array   | ARRAY
+ local_schema | array_test | float_array_array  | ARRAY
+ local_schema | array_test | double_array_array | ARRAY
+(10 rows)
+
+SELECT * FROM local_schema.array_test;
+    str_array    | int_array |             long_array             |  float_array  |    double_array     |     str_array_array      | int_array_array |                 long_array_array                  |   float_array_array   |      double_array_array       
+-----------------+-----------+------------------------------------+---------------+---------------------+--------------------------+-----------------+---------------------------------------------------+-----------------------+-------------------------------
+ {one,two,three} | {1,2,3}   | {1000000000,2000000000,3000000000} | {1.1,2.2,3.3} | {1.111,2.222,3.333} | {{one,two},{three,four}} | {{1,2},{3,4}}   | {{1000000000,2000000000},{3000000000,4000000000}} | {{1.1,2.2},{3.3,4.4}} | {{1.111,2.222},{3.333,4.444}}
+(1 row)
+
+SELECT COUNT(1) FROM local_schema.array_test WHERE 'two' = any(str_array);
+ count 
+-------
+     1
+(1 row)
 
 -- ===================================================================
 -- clean up

--- a/sql/treasuredata_fdw.sql.erb
+++ b/sql/treasuredata_fdw.sql.erb
@@ -108,15 +108,18 @@ FROM information_schema.columns
 WHERE table_schema = 'local_schema'
 ORDER BY table_name, ordinal_position;
 SELECT code, size, method FROM local_schema.www_access ORDER BY size, code LIMIT 5;
-SET client_min_messages = 'warning';
 IMPORT FOREIGN SCHEMA treasuredata_fdw LIMIT TO (array_test)
 FROM SERVER treasuredata_server
 INTO local_schema OPTIONS (
     apikey '<%= @apikey %>',
     query_engine '<%= @query_engine %>'
 );
-RESET client_min_messages;
-\det local_schema.array_test
+SELECT table_schema, table_name, column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = 'local_schema' AND table_name = 'array_test'
+ORDER BY table_name, ordinal_position;
+SELECT * FROM local_schema.array_test;
+SELECT COUNT(1) FROM local_schema.array_test WHERE 'two' = any(str_array);
 -- ===================================================================
 -- clean up
 -- ===================================================================

--- a/sql/treasuredata_fdw.sql.erb
+++ b/sql/treasuredata_fdw.sql.erb
@@ -108,6 +108,18 @@ FROM information_schema.columns
 WHERE table_schema = 'local_schema'
 ORDER BY table_name, ordinal_position;
 SELECT code, size, method FROM local_schema.www_access ORDER BY size, code LIMIT 5;
+SET client_min_messages = 'warning';
+IMPORT FOREIGN SCHEMA treasuredata_fdw LIMIT TO (array_test)
+FROM SERVER treasuredata_server
+INTO local_schema OPTIONS (
+    apikey '<%= @apikey %>',
+    query_engine '<%= @query_engine %>'
+);
+RESET client_min_messages;
+\det local_schema.array_test
+-- ===================================================================
+-- clean up
+-- ===================================================================
 DROP FOREIGN TABLE td_www_access_dst;
 DROP FOREIGN TABLE td_summary_in_www_access;
 DROP FOREIGN TABLE td_www_access;

--- a/sql/treasuredata_fdw.sql.erb
+++ b/sql/treasuredata_fdw.sql.erb
@@ -82,9 +82,22 @@ SERVER treasuredata_server OPTIONS (
 );
 SELECT * FROM td_array_test;
 SELECT COUNT(1) FROM td_array_test WHERE 'two' = any(str_array);
+CREATE SCHEMA local_schema;
+IMPORT FOREIGN SCHEMA sample_datasets
+FROM SERVER treasuredata_server
+INTO local_schema OPTIONS (
+    apikey '<%= @apikey %>',
+    query_engine '<%= @query_engine %>'
+);
+SELECT table_schema, table_name, column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = 'local_schema'
+ORDER BY table_name, ordinal_position;
+SELECT code, size, method FROM local_schema.www_access ORDER BY size, code LIMIT 5;
 DROP FOREIGN TABLE td_www_access_dst;
 DROP FOREIGN TABLE td_summary_in_www_access;
 DROP FOREIGN TABLE td_www_access;
 DROP FOREIGN TABLE td_array_test;
+DROP SCHEMA local_schema CASCADE;
 DROP SERVER treasuredata_server;
 DROP EXTENSION treasuredata_fdw CASCADE;

--- a/sql/treasuredata_fdw.sql.erb
+++ b/sql/treasuredata_fdw.sql.erb
@@ -82,6 +82,9 @@ SERVER treasuredata_server OPTIONS (
 );
 SELECT * FROM td_array_test;
 SELECT COUNT(1) FROM td_array_test WHERE 'two' = any(str_array);
+-- ===================================================================
+-- import foreign schema
+-- ===================================================================
 CREATE SCHEMA local_schema;
 IMPORT FOREIGN SCHEMA sample_datasets
 FROM SERVER treasuredata_server
@@ -98,6 +101,7 @@ DROP FOREIGN TABLE td_www_access_dst;
 DROP FOREIGN TABLE td_summary_in_www_access;
 DROP FOREIGN TABLE td_www_access;
 DROP FOREIGN TABLE td_array_test;
+SET client_min_messages = 'error'; -- pg9.6 print NOTICE log in the next command but pg9.5 does not
 DROP SCHEMA local_schema CASCADE;
 DROP SERVER treasuredata_server;
 DROP EXTENSION treasuredata_fdw CASCADE;

--- a/treasuredata_fdw.c
+++ b/treasuredata_fdw.c
@@ -2308,6 +2308,8 @@ treasuredataImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 			(errmsg("remote_database: %s, server: %s",
 					stmt->remote_schema, stmt->server_name)));
 
+	/* Note that imported tables will NOT include time column
+	   since TD API does not return time column.*/
 	commands = importSchema(apikey, endpoint, query_engine, stmt->remote_schema,
 							stmt->server_name, commands);
 

--- a/treasuredata_fdw.c
+++ b/treasuredata_fdw.c
@@ -2319,7 +2319,7 @@ treasuredataImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 
 	/* Note that imported tables will NOT include time column
 	   since TD API does not return time column.*/
-	tables = getTables(apikey, endpoint,stmt->remote_schema);
+	tables = getTableSchemas(apikey, endpoint, stmt->remote_schema);
 
 	for (i = 0; i < tables->numtables; i++)
 	{

--- a/treasuredata_fdw.c
+++ b/treasuredata_fdw.c
@@ -310,9 +310,10 @@ static void treasuredataExplainForeignModify(ModifyTableState *mtstate,
 static bool treasuredataAnalyzeForeignTable(Relation relation,
         AcquireSampleRowsFunc *func,
         BlockNumber *totalpages);
+#endif
 static List *treasuredataImportForeignSchema(ImportForeignSchemaStmt *stmt,
         Oid serverOid);
-#endif
+
 
 /*
  * Helper functions
@@ -391,10 +392,10 @@ treasuredata_fdw_handler(PG_FUNCTION_ARGS)
 
 	/* Support functions for ANALYZE */
 	routine->AnalyzeForeignTable = treasuredataAnalyzeForeignTable;
-
+#endif
 	/* Support functions for IMPORT FOREIGN SCHEMA */
 	routine->ImportForeignSchema = treasuredataImportForeignSchema;
-#endif
+
 	PG_RETURN_POINTER(routine);
 }
 
@@ -2259,6 +2260,7 @@ analyze_row_processor(PGresult *res, int row, TdFdwAnalyzeState *astate)
 		MemoryContextSwitchTo(oldcontext);
 	}
 }
+#endif
 
 /*
  * Import a foreign schema
@@ -2266,268 +2268,55 @@ analyze_row_processor(PGresult *res, int row, TdFdwAnalyzeState *astate)
 static List *
 treasuredataImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 {
-	List	   *commands = NIL;
-	bool		import_collate = true;
-	bool		import_default = false;
-	bool		import_not_null = true;
-	ForeignServer *server;
-	UserMapping *mapping;
-	PGconn	   *conn;
-	StringInfoData buf;
-	PGresult   *volatile res = NULL;
-	int			numrows,
-	            i;
-	ListCell   *lc;
+	List		*commands = NIL;
+	char		*endpoint = NULL;
+	char		*query_engine = NULL;
+	char		*apikey = NULL;
+	ListCell	*lc = NULL;
 
 	/* Parse statement options */
 	foreach(lc, stmt->options)
 	{
 		DefElem    *def = (DefElem *) lfirst(lc);
 
-		if (strcmp(def->defname, "import_collate") == 0)
-			import_collate = defGetBoolean(def);
-		else if (strcmp(def->defname, "import_default") == 0)
-			import_default = defGetBoolean(def);
-		else if (strcmp(def->defname, "import_not_null") == 0)
-			import_not_null = defGetBoolean(def);
+		if (strcmp(def->defname, "apikey") == 0)
+			apikey = defGetString(def);
+		else if (strcmp(def->defname, "endpoint") == 0)
+			endpoint = defGetString(def);
+		else if (strcmp(def->defname, "query_engine") == 0)
+			query_engine = defGetString(def);
 		else
 			ereport(ERROR,
 			        (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
 			         errmsg("invalid option \"%s\"", def->defname)));
 	}
 
-	/*
-	 * Get connection to the foreign server.  Connection manager will
-	 * establish new connection if necessary.
-	 */
-	server = GetForeignServer(serverOid);
-	mapping = GetUserMapping(GetUserId(), server->serverid);
-	conn = GetConnection(server, mapping, false);
+	/* Validate options */
+	if (apikey == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_DYNAMIC_PARAMETER_VALUE_NEEDED),
+				 errmsg("apikey is required for treasuredata_fdw foreign tables")));
+	if (query_engine == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_DYNAMIC_PARAMETER_VALUE_NEEDED),
+				 errmsg("query_engine is required for treasuredata_fdw foreign tables")));
 
-	/* Don't attempt to import collation if remote server hasn't got it */
-	if (PQserverVersion(conn) < 90100)
-		import_collate = false;
+	ereport(DEBUG1,
+			(errmsg("apikey: %s, endpoint: %s, query_engine: %s",
+					apikey, endpoint, query_engine)));
+	ereport(DEBUG1,
+			(errmsg("remote_database: %s, server: %s",
+					stmt->remote_schema, stmt->server_name)));
 
-	/* Create workspace for strings */
-	initStringInfo(&buf);
+	commands = importSchema(apikey, endpoint, query_engine, stmt->remote_schema,
+							stmt->server_name, commands);
 
-	/* In what follows, do not risk leaking any PGresults. */
-	PG_TRY();
-	{
-		/* Check that the schema really exists */
-		appendStringInfoString(&buf, "SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = ");
-		deparseStringLiteral(&buf, stmt->remote_schema);
-
-		res = PQexec(conn, buf.data);
-		if (PQresultStatus(res) != PGRES_TUPLES_OK)
-			pgfdw_report_error(ERROR, res, conn, false, buf.data);
-
-		if (PQntuples(res) != 1)
-			ereport(ERROR,
-			        (errcode(ERRCODE_FDW_SCHEMA_NOT_FOUND),
-			         errmsg("schema \"%s\" is not present on foreign server \"%s\"",
-			                stmt->remote_schema, server->servername)));
-
-		PQclear(res);
-		res = NULL;
-		resetStringInfo(&buf);
-
-		/*
-		 * Fetch all table data from this schema, possibly restricted by
-		 * EXCEPT or LIMIT TO.  (We don't actually need to pay any attention
-		 * to EXCEPT/LIMIT TO here, because the core code will filter the
-		 * statements we return according to those lists anyway.  But it
-		 * should save a few cycles to not process excluded tables in the
-		 * first place.)
-		 *
-		 * Note: because we run the connection with search_path restricted to
-		 * pg_catalog, the format_type() and pg_get_expr() outputs will always
-		 * include a schema name for types/functions in other schemas, which
-		 * is what we want.
-		 */
-		if (import_collate)
-			appendStringInfoString(&buf,
-			                       "SELECT relname, "
-			                       "  attname, "
-			                       "  format_type(atttypid, atttypmod), "
-			                       "  attnotnull, "
-			                       "  pg_get_expr(adbin, adrelid), "
-			                       "  collname, "
-			                       "  collnsp.nspname "
-			                       "FROM pg_class c "
-			                       "  JOIN pg_namespace n ON "
-			                       "    relnamespace = n.oid "
-			                       "  LEFT JOIN pg_attribute a ON "
-			                       "    attrelid = c.oid AND attnum > 0 "
-			                       "      AND NOT attisdropped "
-			                       "  LEFT JOIN pg_attrdef ad ON "
-			                       "    adrelid = c.oid AND adnum = attnum "
-			                       "  LEFT JOIN pg_collation coll ON "
-			                       "    coll.oid = attcollation "
-			                       "  LEFT JOIN pg_namespace collnsp ON "
-			                       "    collnsp.oid = collnamespace ");
-		else
-			appendStringInfoString(&buf,
-			                       "SELECT relname, "
-			                       "  attname, "
-			                       "  format_type(atttypid, atttypmod), "
-			                       "  attnotnull, "
-			                       "  pg_get_expr(adbin, adrelid), "
-			                       "  NULL, NULL "
-			                       "FROM pg_class c "
-			                       "  JOIN pg_namespace n ON "
-			                       "    relnamespace = n.oid "
-			                       "  LEFT JOIN pg_attribute a ON "
-			                       "    attrelid = c.oid AND attnum > 0 "
-			                       "      AND NOT attisdropped "
-			                       "  LEFT JOIN pg_attrdef ad ON "
-			                       "    adrelid = c.oid AND adnum = attnum ");
-
-		appendStringInfoString(&buf,
-		                       "WHERE c.relkind IN ('r', 'v', 'f', 'm') "
-		                       "  AND n.nspname = ");
-		deparseStringLiteral(&buf, stmt->remote_schema);
-
-		/* Apply restrictions for LIMIT TO and EXCEPT */
-		if (stmt->list_type == FDW_IMPORT_SCHEMA_LIMIT_TO ||
-		        stmt->list_type == FDW_IMPORT_SCHEMA_EXCEPT)
-		{
-			bool		first_item = true;
-
-			appendStringInfoString(&buf, " AND c.relname ");
-			if (stmt->list_type == FDW_IMPORT_SCHEMA_EXCEPT)
-				appendStringInfoString(&buf, "NOT ");
-			appendStringInfoString(&buf, "IN (");
-
-			/* Append list of table names within IN clause */
-			foreach(lc, stmt->table_list)
-			{
-				RangeVar   *rv = (RangeVar *) lfirst(lc);
-
-				if (first_item)
-					first_item = false;
-				else
-					appendStringInfoString(&buf, ", ");
-				deparseStringLiteral(&buf, rv->relname);
-			}
-			appendStringInfoChar(&buf, ')');
-		}
-
-		/* Append ORDER BY at the end of query to ensure output ordering */
-		appendStringInfoString(&buf, " ORDER BY c.relname, a.attnum");
-
-		/* Fetch the data */
-		res = PQexec(conn, buf.data);
-		if (PQresultStatus(res) != PGRES_TUPLES_OK)
-			pgfdw_report_error(ERROR, res, conn, false, buf.data);
-
-		/* Process results */
-		numrows = PQntuples(res);
-		/* note: incrementation of i happens in inner loop's while() test */
-		for (i = 0; i < numrows;)
-		{
-			char	   *tablename = PQgetvalue(res, i, 0);
-			bool		first_item = true;
-
-			resetStringInfo(&buf);
-			appendStringInfo(&buf, "CREATE FOREIGN TABLE %s (\n",
-			                 quote_identifier(tablename));
-
-			/* Scan all rows for this table */
-			do
-			{
-				char	   *attname;
-				char	   *typename;
-				char	   *attnotnull;
-				char	   *attdefault;
-				char	   *collname;
-				char	   *collnamespace;
-
-				/* If table has no columns, we'll see nulls here */
-				if (PQgetisnull(res, i, 1))
-					continue;
-
-				attname = PQgetvalue(res, i, 1);
-				typename = PQgetvalue(res, i, 2);
-				attnotnull = PQgetvalue(res, i, 3);
-				attdefault = PQgetisnull(res, i, 4) ? (char *) NULL :
-				             PQgetvalue(res, i, 4);
-				collname = PQgetisnull(res, i, 5) ? (char *) NULL :
-				           PQgetvalue(res, i, 5);
-				collnamespace = PQgetisnull(res, i, 6) ? (char *) NULL :
-				                PQgetvalue(res, i, 6);
-
-				if (first_item)
-					first_item = false;
-				else
-					appendStringInfoString(&buf, ",\n");
-
-				/* Print column name and type */
-				appendStringInfo(&buf, "  %s %s",
-				                 quote_identifier(attname),
-				                 typename);
-
-				/*
-				 * Add column_name option so that renaming the foreign table's
-				 * column doesn't break the association to the underlying
-				 * column.
-				 */
-				appendStringInfoString(&buf, " OPTIONS (column_name ");
-				deparseStringLiteral(&buf, attname);
-				appendStringInfoChar(&buf, ')');
-
-				/* Add COLLATE if needed */
-				if (import_collate && collname != NULL && collnamespace != NULL)
-					appendStringInfo(&buf, " COLLATE %s.%s",
-					                 quote_identifier(collnamespace),
-					                 quote_identifier(collname));
-
-				/* Add DEFAULT if needed */
-				if (import_default && attdefault != NULL)
-					appendStringInfo(&buf, " DEFAULT %s", attdefault);
-
-				/* Add NOT NULL if needed */
-				if (import_not_null && attnotnull[0] == 't')
-					appendStringInfoString(&buf, " NOT NULL");
-			}
-			while (++i < numrows &&
-			        strcmp(PQgetvalue(res, i, 0), tablename) == 0);
-
-			/*
-			 * Add server name and table-level options.  We specify remote
-			 * schema and table name as options (the latter to ensure that
-			 * renaming the foreign table doesn't break the association).
-			 */
-			appendStringInfo(&buf, "\n) SERVER %s\nOPTIONS (",
-			                 quote_identifier(server->servername));
-
-			appendStringInfoString(&buf, "schema_name ");
-			deparseStringLiteral(&buf, stmt->remote_schema);
-			appendStringInfoString(&buf, ", table_name ");
-			deparseStringLiteral(&buf, tablename);
-
-			appendStringInfoString(&buf, ");");
-
-			commands = lappend(commands, pstrdup(buf.data));
-		}
-
-		/* Clean up */
-		PQclear(res);
-		res = NULL;
-	}
-	PG_CATCH();
-	{
-		if (res)
-			PQclear(res);
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
-
-	ReleaseConnection(conn);
+	ereport(DEBUG1,
+			(errmsg("number of import commands: %d",
+					list_length(commands))));
 
 	return commands;
 }
-#endif
 
 /*
  * Create a tuple from the specified row of the PGresult.


### PR DESCRIPTION
Implemented import foreign schema.
Treasure Data originally doesn't have PostgreSQL like schema. I implemented import foreign schema to import tables on the specified TD database into the specified PostgreSQL schema. I suppose this is a reasonable implementation since tables can be accessed by the syntax "\<database\>.\<table\>" in TD and "\<schema\>.\<table\>" in PostgreSQL. i.e. database of TD and schema of PostgreSQL work the same manner in the query syntax.
Please note "time" column will NOT be imported by IMPORT FOREIGN SCHEMA because TD table API does not include time column in the table schema.